### PR TITLE
Two different items - sorry ...

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -79,6 +79,7 @@ var DELETE_ON_GET = true;
 			var db = Titanium.Database.open('cache');
 			if (DELETE_ON_GET) {
 				Ti.API.debug("CACHE DELETE_ON_GET");
+				db.execute('CREATE TABLE IF NOT EXISTS cache (key TEXT UNIQUE, value TEXT, expiration INTEGER)');
 				db.execute('DELETE FROM cache WHERE expiration <= ?', current_timestamp());
 			}
 			var rs = db.execute('SELECT value FROM cache WHERE key = ?', key);


### PR DESCRIPTION
Hi,

This has been great. Thanks for writing it.

I fixed a bug: current_timestamp() was returning millis, but was being combined with time in seconds elsewhere.

Also, I added an option with a flag to not start the background process, and instead perform the deletes when asked for a get. I can imagine that the choice for this would depend on the app. For mine, this option (with no background process) makes a lot of sense.

Use these changes as you please.

Robb
